### PR TITLE
Type annotation syntax

### DIFF
--- a/compile/ast/ast.go
+++ b/compile/ast/ast.go
@@ -561,7 +561,8 @@ type Function struct {
 	// Vars maps variable names to slot indexes.
 	// Local slots: < SharedSlotStart, Shared slots: >= SharedSlotStart
 	// Set by ast.Blocks for functions with blocks.
-	Vars map[string]int16
+	Vars             map[string]int16
+	ReturnAnnotation string
 }
 
 func (a *Function) String() string {
@@ -628,7 +629,8 @@ type Param struct {
 	Name   Ident // including prefix @ . _
 	End    int32
 	// Unused is set if the parameter was followed by /*unused*/
-	Unused bool
+	Unused      bool
+	Annotations string
 }
 
 func (a *Param) String() string {

--- a/compile/function.go
+++ b/compile/function.go
@@ -4,6 +4,8 @@
 package compile
 
 import (
+	"strings"
+
 	"github.com/apmckinlay/gsuneido/compile/ast"
 	tok "github.com/apmckinlay/gsuneido/compile/tokens"
 	. "github.com/apmckinlay/gsuneido/core"
@@ -22,6 +24,7 @@ func (p *Parser) function(inClass bool) (result *ast.Function) {
 	p.InitFuncInfo()
 	params := p.params(inClass)
 	pos1 := p.EndPos
+	returnAnnotation := p.annotation()
 	p.Match(tok.LCurly)
 	pos2 := p.EndPos
 	body := p.statements()
@@ -29,6 +32,7 @@ func (p *Parser) function(inClass bool) (result *ast.Function) {
 	p.processFinal()
 	fn := &ast.Function{Params: params, Body: body, Final: p.final,
 		HasBlocks: p.hasBlocks, Pos1: pos1, Pos2: pos2}
+	fn.ReturnAnnotation = returnAnnotation
 	p.funcInfo = funcInfoSave
 	return fn
 }
@@ -55,7 +59,7 @@ func (p *Parser) processFinal() {
 func (p *Parser) params(inClass bool) []ast.Param {
 	p.Match(tok.LParen)
 	var params []ast.Param
-	addParam := func(name string, pos int32, unused bool, def Value) {
+	addParam := func(name string, pos int32, unused bool, def Value, annotation string) {
 		if name == "unused" || name == "@unused" {
 			unused = true
 		}
@@ -68,6 +72,7 @@ func (p *Parser) params(inClass bool) []ast.Param {
 			}
 		}
 		param := mkParam(name, pos, p.EndPos, unused, def)
+		param.Annotations = annotation
 		params = append(params, param)
 	}
 	if p.Token == tok.At {
@@ -76,7 +81,7 @@ func (p *Parser) params(inClass bool) []ast.Param {
 		name := p.Text
 		unused := p.unusedAhead()
 		p.MatchIdent()
-		addParam("@"+name, pos, unused, nil)
+		addParam("@"+name, pos, unused, nil, "object")
 		p.final[name] = disqualified
 	} else {
 		defs := false
@@ -94,6 +99,9 @@ func (p *Parser) params(inClass bool) []ast.Param {
 			unused := p.unusedAhead()
 			p.MatchIdent()
 			p.checkForDupParam(params, name)
+
+			annotation := p.annotation()
+
 			if p.MatchIf(tok.Eq) {
 				wasString := p.Token == tok.String || p.Token == tok.Symbol
 				defs = true
@@ -101,19 +109,34 @@ func (p *Parser) params(inClass bool) []ast.Param {
 				if _, ok := def.(SuStr); ok && !wasString {
 					p.Error("parameter defaults must be constants")
 				}
-				addParam(name, pos, unused, def)
+				addParam(name, pos, unused, def, annotation)
 				p.MatchIf(tok.Comma)
 			} else {
 				if defs {
 					p.Error("default parameters must come last")
 				}
-				addParam(name, pos, unused, nil)
+				addParam(name, pos, unused, nil, annotation)
 				p.MatchIf(tok.Comma)
 			}
 		}
 	}
 	p.Match(tok.RParen)
 	return params
+}
+
+func (p *Parser) annotation() string {
+	if !p.MatchIf(tok.Colon) {
+		return ""
+	}
+
+	var annotation string
+	for {
+		annotation += p.MatchIdent() + "|"
+		if !p.MatchIf(tok.BitOr) {
+			break
+		}
+	}
+	return strings.TrimSuffix(annotation, "|")
 }
 
 func mkParam(name string, pos, end int32, unused bool, def Value) ast.Param {

--- a/compile/parse_test.go
+++ b/compile/parse_test.go
@@ -241,6 +241,39 @@ func TestParseParams(t *testing.T) {
 	test("(.a,._b=1)")
 }
 
+func TestParamAnnotationFunc(t *testing.T) {
+	test := func(src string, expected ...string) {
+		t.Helper()
+		p := NewParser(src + "{}")
+		result := p.function(false)
+		assert.T(t).This(p.Token).Is(tok.Eof)
+		for i, want := range expected {
+			assert.T(t).This(result.Params[i].Annotations).Is(want)
+		}
+	}
+	test("(a: string)", "string")
+	test("(a: string | number)", "string|number")
+	test("(a: Foo | Bar | Baz)", "Foo|Bar|Baz")
+	test("(a, b: Foo)", "", "Foo")
+	test("(a: Foo, b: Bar | Baz)", "Foo", "Bar|Baz")
+	test("(a: string = 1)", "string")
+}
+
+func TestReturnAnnotationFunc(t *testing.T) {
+	test := func(src string, expected string) {
+		t.Helper()
+		p := NewParser(src + "{}")
+		result := p.function(false)
+		assert.T(t).This(p.Token).Is(tok.Eof)
+		assert.T(t).This(result.ReturnAnnotation).Is(expected)
+	}
+	test("()", "")
+	test("() : string", "string")
+	test("() : string | number", "string|number")
+	test("() : Foo | Bar | Baz", "Foo|Bar|Baz")
+	test("(a: Foo) : Bar", "Bar")
+}
+
 func TestParseStatements(t *testing.T) {
 	core.DefaultSingleQuotes = true
 	defer func() { core.DefaultSingleQuotes = false }()


### PR DESCRIPTION
- Pair programmed changes to the parser
- Added tests in parse_test.go

I've always patch files!
[0001-added-syntax-for-source-code-type-annotations.patch](https://github.com/user-attachments/files/27610275/0001-added-syntax-for-source-code-type-annotations.patch)
[0002-added-parser-tests.patch](https://github.com/user-attachments/files/27610276/0002-added-parser-tests.patch)
