### PR TITLE
change the sandbox to only be enabled when the AI is running

### DIFF
--- a/builtin/aiagent.go
+++ b/builtin/aiagent.go
@@ -22,7 +22,6 @@ type suAgent struct {
 var _ = builtin(AiAgent, "(baseURL, apiKey, model, callback, prompt = '')")
 
 func AiAgent(th *Thread, args []Value) Value {
-	EnableSandbox()
 	baseURL := ToStr(args[0])
 	apiKey := ToStr(args[1])
 	model := ToStr(args[2])
@@ -36,7 +35,7 @@ func AiAgent(th *Thread, args []Value) Value {
 		th:       t2,
 		callback: callback,
 		agent: llm.NewAgent(baseURL, apiKey, model, prompt,
-			outputCallback(t2, callback)),
+			outputCallback(t2, callback), EnableSandbox, DisableSandbox),
 	}
 	return a
 }
@@ -184,6 +183,5 @@ func agent_Close(this Value) Value {
 	a := this.(*suAgent)
 	a.agent.Interrupt()
 	a.th.Close()
-	DisableSandbox()
 	return nil
 }

--- a/llm/agent.go
+++ b/llm/agent.go
@@ -14,22 +14,25 @@ import (
 )
 
 type Agent struct {
-	client        *OpenAIClient
-	toolClient    *ToolClient
-	model         string
-	prompt        string
-	history       []Message
-	outfn         OutFn
-	cancel        context.CancelFunc
-	logFile       *os.File
-	rawLogFile    *os.File
-	mu            sync.Mutex
-	inProgress    bool
-	thinkBuf      strings.Builder
-	thinkDirty    bool
-	loadedContent string  // content from LoadConversation to copy when log is created
-	usage         *Usage  // token usage from last response
-	totalCost     float64 // cumulative cost across all requests
+	client         *OpenAIClient
+	toolClient     *ToolClient
+	model          string
+	prompt         string
+	history        []Message
+	outfn          OutFn
+	cancel         context.CancelFunc
+	logFile        *os.File
+	rawLogFile     *os.File
+	mu             sync.Mutex
+	inProgress     bool
+	thinkBuf       strings.Builder
+	thinkDirty     bool
+	loadedContent  string  // content from LoadConversation to copy when log is created
+	usage          *Usage  // token usage from last response
+	totalCost      float64 // cumulative cost across all requests
+	sandboxMode    bool
+	EnableSandbox  func()
+	DisableSandbox func()
 }
 
 // OutFn is the push callback for streaming output.
@@ -76,18 +79,21 @@ func (a *ToolApproval) Wait(ctx context.Context) (approvalDecision, error) {
 
 // NewAgent creates an agent.
 // prompt is optional.
-func NewAgent(baseURL, apiKey, model, prompt string, outfn OutFn) *Agent {
+func NewAgent(baseURL, apiKey, model, prompt string, outfn OutFn, enableSandbox, disableSandbox func()) *Agent {
 	toolClient, err := NewToolClient()
 	if err != nil {
 		panic("NewAgent: " + err.Error())
 	}
 
 	agent := &Agent{
-		client:     NewOpenAIClient(baseURL, apiKey),
-		toolClient: toolClient,
-		model:      model,
-		prompt:     prompt,
-		outfn:      outfn,
+		client:         NewOpenAIClient(baseURL, apiKey),
+		toolClient:     toolClient,
+		model:          model,
+		prompt:         prompt,
+		outfn:          outfn,
+		sandboxMode:    false,
+		EnableSandbox:  enableSandbox,
+		DisableSandbox: disableSandbox,
 	}
 	agent.resetHistory()
 	return agent
@@ -115,6 +121,16 @@ func (agent *Agent) Input(input string) {
 func (agent *Agent) Interrupt() {
 	if agent.cancel != nil {
 		agent.cancel()
+	}
+	agent.mu.Lock()
+	disableSandboxIfNeeded(agent)
+	agent.mu.Unlock()
+}
+
+func disableSandboxIfNeeded(agent *Agent) {
+	if agent.sandboxMode {
+		agent.DisableSandbox()
+		agent.sandboxMode = false
 	}
 }
 
@@ -169,11 +185,19 @@ func (agent *Agent) request(input string) {
 	defer func() {
 		agent.mu.Lock()
 		agent.inProgress = false
+		disableSandboxIfNeeded(agent)
 		agent.mu.Unlock()
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
 	agent.cancel = cancel
 	defer cancel()
+
+	if agent.sandboxMode == false {
+		agent.EnableSandbox()
+		agent.mu.Lock()
+		agent.sandboxMode = true
+		agent.mu.Unlock()
+	}
 
 	agent.history = append(agent.history, Message{Role: "user", Content: input})
 	agent.logMessage("user", input)


### PR DESCRIPTION
also fixed bug when a dummy AiAgent being closed two times causing sandbox not enabled on the active AiAgent, like running the following code on workspace:

agent = AiAgent(AiAgentControl.AiAgentControl_url, 'key', 'model', function(@unused){}, '')
agent.Close()
agent.Close()