### PR TITLE
Added param annotations for builtins

### DIFF
--- a/builtin/adler32.go
+++ b/builtin/adler32.go
@@ -48,7 +48,7 @@ func (suAdler32) Lookup(_ *Thread, method string) Value {
 
 var adler32Methods = methods("adler32")
 
-var _ = method(adler32_Update, "(string) :unknown")
+var _ = method(adler32_Update, "(string :string) :unknown")
 
 func adler32_Update(this, arg Value) Value {
 	io.WriteString(this.(suAdler32).hash, ToStr(arg))

--- a/builtin/aiagent.go
+++ b/builtin/aiagent.go
@@ -19,7 +19,7 @@ type suAgent struct {
 	callback Value
 }
 
-var _ = builtin(AiAgent, "(baseURL, apiKey, model, callback, prompt = '') :unknown")
+var _ = builtin(AiAgent, "(baseURL :string, apiKey :string, model :string, callback, prompt :string = '') :unknown")
 
 func AiAgent(th *Thread, args []Value) Value {
 	baseURL := ToStr(args[0])
@@ -94,14 +94,14 @@ func outputCallback(th *Thread, callback Value) func(what, data string, approval
 var agentMethods = methods("agent")
 var toolApprovalMethods = methods("toolapproval")
 
-var _ = method(toolapproval_Allow, "(text = '') :void")
+var _ = method(toolapproval_Allow, "(text :string = '') :void")
 
 func toolapproval_Allow(this Value, text Value) Value {
 	this.(*suToolApproval).approval.Allow(ToStr(text))
 	return nil
 }
 
-var _ = method(toolapproval_Deny, "(text = '') :void")
+var _ = method(toolapproval_Deny, "(text :string = '') :void")
 
 func toolapproval_Deny(this Value, text Value) Value {
 	this.(*suToolApproval).approval.Deny(ToStr(text))
@@ -120,7 +120,7 @@ func toolapproval_After(this Value) Value {
 	return SuStr(this.(*suToolApproval).approval.After)
 }
 
-var _ = method(agent_Input, "(input) :void")
+var _ = method(agent_Input, "(input :string) :void")
 
 func agent_Input(this, input Value) Value {
 	this.(*suAgent).agent.Input(ToStr(input))
@@ -134,7 +134,7 @@ func agent_Interrupt(this Value) Value {
 	return nil
 }
 
-var _ = method(agent_SetModel, "(model) :void")
+var _ = method(agent_SetModel, "(model :string) :void")
 
 func agent_SetModel(this, model Value) Value {
 	this.(*suAgent).agent.SetModel(ToStr(model))
@@ -148,7 +148,7 @@ func agent_ClearHistory(this Value) Value {
 	return nil
 }
 
-var _ = method(agent_LoadConversation, "(filename) :true")
+var _ = method(agent_LoadConversation, "(filename :string) :true")
 
 func agent_LoadConversation(th *Thread, this Value, args []Value) Value {
 	a := this.(*suAgent)

--- a/builtin/argon2.go
+++ b/builtin/argon2.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(Argon2id, "(password, salt) :string")
+var _ = builtin(Argon2id, "(password :string, salt :string) :string")
 
 func Argon2id(a, b Value) Value {
 	password := ToStr(a)

--- a/builtin/basemeth.go
+++ b/builtin/basemeth.go
@@ -49,7 +49,7 @@ func base_GetDefault(th *Thread, this Value, args []Value) Value {
 	return args[1]
 }
 
-var _ = method(base_MemberQ, "(string) :boolean")
+var _ = method(base_MemberQ, "(string :string) :boolean")
 
 func base_MemberQ(th *Thread, this Value, arg []Value) Value {
 	m := ToStr(arg[0])

--- a/builtin/channel.go
+++ b/builtin/channel.go
@@ -18,7 +18,7 @@ type suChannel struct {
 
 var sc_timeout = 10 * time.Second
 
-var _ = builtin(Channel, "(size = 4) :unknown")
+var _ = builtin(Channel, "(size :number = 4) :unknown")
 
 func Channel(size Value) Value {
 	return &suChannel{ch: make(chan Value, IfInt(size))}

--- a/builtin/class.go
+++ b/builtin/class.go
@@ -34,7 +34,7 @@ func class_BaseQ(th *Thread, this Value, args []Value) Value {
 		}))
 }
 
-var _ = method(class_MethodQ, "(string) :boolean")
+var _ = method(class_MethodQ, "(string :string) :boolean")
 
 func class_MethodQ(th *Thread, this Value, args []Value) Value {
 	m := ToStr(args[0])
@@ -48,7 +48,7 @@ func class_MethodQ(th *Thread, this Value, args []Value) Value {
 	}))
 }
 
-var _ = method(class_MethodClass, "(string) :false|unknown")
+var _ = method(class_MethodClass, "(string :string) :false|unknown")
 
 func class_MethodClass(th *Thread, this Value, args []Value) Value {
 	m := ToStr(args[0])
@@ -68,7 +68,7 @@ func class_ReadonlyQ(this Value) Value {
 	return True
 }
 
-var _ = method(class_StartCoverage, "(count = false) :void")
+var _ = method(class_StartCoverage, "(count :boolean = false) :void")
 
 func class_StartCoverage(this, a Value) Value {
 	if !options.Coverage.Load() {

--- a/builtin/construct.go
+++ b/builtin/construct.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(Construct, "(what, suffix='') :object|unknown")
+var _ = builtin(Construct, "(what, suffix :string ='') :object|unknown")
 
 func Construct(th *Thread, args []Value) Value {
 	what := args[0]

--- a/builtin/database.go
+++ b/builtin/database.go
@@ -20,7 +20,7 @@ type suDatabaseGlobal struct {
 func init() {
 	Global.Builtin("Database", &suDatabaseGlobal{
 		SuBuiltin{Fn: Database,
-			BuiltinParams: BuiltinParams{ParamSpec: params("(string)")}}})
+			BuiltinParams: BuiltinParams{ParamSpec: params("(string :string)")}}})
 }
 
 func Database(th *Thread, args []Value) Value {
@@ -30,7 +30,7 @@ func Database(th *Thread, args []Value) Value {
 
 var databaseMethods = methods("db")
 
-var _ = staticMethod(db_Auth, "(data) :boolean")
+var _ = staticMethod(db_Auth, "(data :string) :boolean")
 
 func db_Auth(th *Thread, args []Value) Value {
 	return SuBool(th.Dbms().Auth(th, ToStr(args[0])))
@@ -66,7 +66,7 @@ func db_Cursors(th *Thread, args []Value) Value {
 	return IntVal(th.Dbms().Cursors())
 }
 
-var _ = staticMethod(db_Dump, "(table = '', to = '', publicKey = '') :string")
+var _ = staticMethod(db_Dump, "(table :string = '', to :string = '', publicKey :string = '') :string")
 
 func db_Dump(th *Thread, args []Value) Value {
 	if dbms, ok := th.Dbms().(*dbms.DbmsLocal); ok {
@@ -93,13 +93,13 @@ func db_Info(th *Thread, args []Value) Value {
 	return th.Dbms().Info()
 }
 
-var _ = staticMethod(db_Kill, "(sessionId) :number")
+var _ = staticMethod(db_Kill, "(sessionId :string) :number")
 
 func db_Kill(th *Thread, args []Value) Value {
 	return IntVal(th.Dbms().Kill(ToStr(args[0])))
 }
 
-var _ = staticMethod(db_Load, "(table, from = '', privateKey = '', passphrase = '') :number")
+var _ = staticMethod(db_Load, "(table :string, from :string = '', privateKey :string = '', passphrase :string = '') :number")
 
 func db_Load(th *Thread, args []Value) Value {
 	if dbms, ok := th.Dbms().(*dbms.DbmsLocal); ok {
@@ -115,13 +115,13 @@ func db_Nonce(th *Thread, args []Value) Value {
 	return SuStr(th.Dbms().Nonce(th))
 }
 
-var _ = staticMethod(db_Schema, "(table) :string")
+var _ = staticMethod(db_Schema, "(table :string) :string")
 
 func db_Schema(th *Thread, args []Value) Value {
 	return SuStr(th.Dbms().Schema(ToStr(args[0])))
 }
 
-var _ = staticMethod(db_SessionId, "(id = '') :string")
+var _ = staticMethod(db_SessionId, "(id :string = '') :string")
 
 func db_SessionId(th *Thread, args []Value) Value {
 	return SuStr(th.SessionId(ToStr(args[0])))
@@ -154,7 +154,7 @@ func db_CorruptedQ(th *Thread, args []Value) Value {
 	return th.Dbms().Exec(th, SuObjectOf(SuStr("Database.Corrupted?")))
 }
 
-var _ = staticMethod(db_Top10, "(table, column) :object")
+var _ = staticMethod(db_Top10, "(table :string, column :string) :object")
 
 func db_Top10(th *Thread, args []Value) Value {
 	table := ToStr(args[0])
@@ -182,7 +182,7 @@ func db_Top10(th *Thread, args []Value) Value {
 	return result
 }
 
-var _ = staticMethod(db_Distinct, "(table) :object")
+var _ = staticMethod(db_Distinct, "(table :string) :object")
 
 func db_Distinct(th *Thread, args []Value) Value {
 	table := ToStr(args[0])
@@ -247,7 +247,7 @@ func (d *suDatabaseGlobal) String() string {
 	return "Database /* builtin class */"
 }
 
-var _ = builtin(DoWithoutTriggers, "(tables, block) :unknown")
+var _ = builtin(DoWithoutTriggers, "(tables :object, block) :unknown")
 
 func DoWithoutTriggers(th *Thread, args []Value) Value {
 	dbms := th.Dbms()

--- a/builtin/date.go
+++ b/builtin/date.go
@@ -147,7 +147,7 @@ var date_members = methodList(dateStaticMethods)
 
 var _ = exportMethods(&DateMethods, "date")
 
-var _ = method(date_MinusDays, "(date) :number")
+var _ = method(date_MinusDays, "(date :date) :number")
 
 func date_MinusDays(this Value, val Value) Value {
 	t1 := toDate(this)
@@ -157,7 +157,7 @@ func date_MinusDays(this Value, val Value) Value {
 	panic("date.MinusDays requires date")
 }
 
-var _ = method(date_MinusSeconds, "(date) :number")
+var _ = method(date_MinusSeconds, "(date :date) :number")
 
 func date_MinusSeconds(this Value, val Value) Value {
 	t1 := toDate(this)
@@ -171,7 +171,7 @@ func date_MinusSeconds(this Value, val Value) Value {
 	panic("date.MinusSeconds requires date")
 }
 
-var _ = method(date_FormatEn, "(format) :string")
+var _ = method(date_FormatEn, "(format :string) :string")
 
 func date_FormatEn(this, arg Value) Value {
 	return SuStr(toDate(this).Format(ToStr(arg)))

--- a/builtin/def.go
+++ b/builtin/def.go
@@ -10,7 +10,7 @@ import (
 
 // DefDef must be called to make Def available
 func DefDef() {
-	builtin(Def, "(name, definition)")
+	builtin(Def, "(name :string, definition)")
 }
 
 func Def(nameVal, val Value) Value {

--- a/builtin/dir.go
+++ b/builtin/dir.go
@@ -18,7 +18,7 @@ import (
 
 const maxDir = 10000
 
-var _ = builtin(dir, "(path='*', files=false, details=false, block=false) :object|void")
+var _ = builtin(dir, "(path :string ='*', files :boolean =false, details :boolean =false, block=false) :object|void")
 
 func dir(th *Thread, args []Value) Value {
 	path := ToStr(args[0])

--- a/builtin/file.go
+++ b/builtin/file.go
@@ -38,7 +38,7 @@ type suFile struct {
 var nFile atomic.Int32
 var _ = AddInfo("builtin.nFile", &nFile)
 
-var _ = builtin(File, "(filename, mode='r', block=false) :unknown")
+var _ = builtin(File, "(filename :string, mode :string ='r', block=false) :unknown")
 
 func File(th *Thread, args []Value) Value {
 	name := ToStr(args[0])
@@ -210,7 +210,7 @@ func file_Readline(this Value) Value {
 	return val
 }
 
-var _ = method(file_Seek, "(offset, origin='set') :void")
+var _ = method(file_Seek, "(offset, origin :string ='set') :void")
 
 func file_Seek(this, arg1, arg2 Value) Value {
 	sf := sfOpen(this)

--- a/builtin/ftsearch.go
+++ b/builtin/ftsearch.go
@@ -40,7 +40,7 @@ func ftsearch_Create() Value {
 	return &suFtsBuilder{b: ftsearch.NewBuilder()}
 }
 
-var _ = staticMethod(ftsearch_Load, "(data) :unknown")
+var _ = staticMethod(ftsearch_Load, "(data :string) :unknown")
 
 func ftsearch_Load(data Value) Value {
 	return newSuFtsIndex(ftsearch.Unpack(ToStr(data)))
@@ -60,7 +60,7 @@ func ftsearch_Members() Value {
 
 var ftsearch_members = methodList(ftsearchMethods)
 
-var _ = staticMethod(ftsearch_Tokens, "(text) :object")
+var _ = staticMethod(ftsearch_Tokens, "(text :string) :object")
 
 func ftsearch_Tokens(text Value) Value {
 	in := ftsearch.NewInput(ToStr(text))
@@ -96,7 +96,7 @@ func (*suFtsBuilder) Lookup(_ *Thread, method string) Value {
 
 var ftsBuilderMethods = methods("ftsBuilder")
 
-var _ = method(ftsBuilder_Add, "(id, title, text) :void")
+var _ = method(ftsBuilder_Add, "(id, title :string, text :string) :void")
 
 func ftsBuilder_Add(this, id, title, text Value) Value {
 	b := this.(*suFtsBuilder).b
@@ -152,7 +152,7 @@ func (*suFtsIndex) Lookup(_ *Thread, method string) Value {
 
 var ftsIndexMethods = methods("ftsIndex")
 
-var _ = method(ftsIndex_Search, "(query, scores = false) :object")
+var _ = method(ftsIndex_Search, "(query :string, scores :boolean = false) :object")
 
 func ftsIndex_Search(this, query, scores Value) Value {
 	scors := ToBool(scores)
@@ -172,7 +172,7 @@ func ftsIndex_Search(this, query, scores Value) Value {
 	return NewSuObject(list)
 }
 
-var _ = method(ftsIndex_Update, "(id, oldTitle, oldText, newTitle, newText) :void")
+var _ = method(ftsIndex_Update, "(id, oldTitle :string, oldText :string, newTitle :string, newText :string) :void")
 
 func ftsIndex_Update(_ *Thread, this Value, args []Value) Value {
 	sfi := this.(*suFtsIndex)
@@ -193,7 +193,7 @@ func ftsIndex_Pack(this Value) Value {
 	return SuStr(sfi.get().Pack())
 }
 
-var _ = method(ftsIndex_WordInfo, "(word) :string")
+var _ = method(ftsIndex_WordInfo, "(word :string) :string")
 
 func ftsIndex_WordInfo(this, word Value) Value {
 	sfi := this.(*suFtsIndex)

--- a/builtin/function.go
+++ b/builtin/function.go
@@ -8,7 +8,7 @@ import (
 	"github.com/apmckinlay/gsuneido/options"
 )
 
-var _ = builtin(CoverageEnable, "(enable) :void")
+var _ = builtin(CoverageEnable, "(enable :boolean) :void")
 
 func CoverageEnable(a Value) Value {
 	options.Coverage.Store(ToBool(a))
@@ -27,7 +27,7 @@ func func_Disasm(this, a Value) Value {
 	return SuStr(DisasmMixed(fn, ToStr(a)))
 }
 
-var _ = method(func_StartCoverage, "(count = false) :void")
+var _ = method(func_StartCoverage, "(count :boolean = false) :void")
 
 func func_StartCoverage(this, a Value) Value {
 	if !options.Coverage.Load() {

--- a/builtin/getenv.go
+++ b/builtin/getenv.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(Getenv, "(string) :string")
+var _ = builtin(Getenv, "(string :string) :string")
 
 func Getenv(arg Value) Value {
 	return SuStr(os.Getenv(ToStr(arg)))

--- a/builtin/global.go
+++ b/builtin/global.go
@@ -8,7 +8,7 @@ import (
 	"github.com/apmckinlay/gsuneido/util/str"
 )
 
-var _ = builtin(global, "(name) :unknown")
+var _ = builtin(global, "(name :string) :unknown")
 
 func global(th *Thread, args []Value) Value {
 	s := ToStr(args[0])

--- a/builtin/httpclient.go
+++ b/builtin/httpclient.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apmckinlay/gsuneido/util/str"
 )
 
-var _ = builtin(HttpClient2, `(method, url,
+var _ = builtin(HttpClient2, `(method :string, url :string,
 	content = '', header = #(), timeout = 60, block = false) :object|void`)
 
 // HttpClient2 is a wrapper around Go net/http
@@ -59,7 +59,7 @@ func HttpClient2(th *Thread, args []Value) Value {
 	}
 }
 
-var _ = builtin(HttpsClient, `(method, url,
+var _ = builtin(HttpsClient, `(method :string, url :string,
 	content = '', header = #(), timeout = 60, block = false) :void|object`)
 
 // HttpsClient makes an HTTPS request embedded cert

--- a/builtin/httpserver.go
+++ b/builtin/httpserver.go
@@ -198,7 +198,7 @@ func httpEnv_WriteHeader(this Value, a, b Value) Value {
 	return nil
 }
 
-var _ = method(httpEnv_Write, "(s) :void")
+var _ = method(httpEnv_Write, "(s :string) :void")
 
 func httpEnv_Write(this Value, a Value) Value {
 	e := this.(*suHttpEnv)

--- a/builtin/library.go
+++ b/builtin/library.go
@@ -19,7 +19,7 @@ func Libraries(th *Thread, args []Value) Value {
 	return &ob
 }
 
-var _ = builtin(Use, "(library) :boolean")
+var _ = builtin(Use, "(library :string) :boolean")
 
 func Use(th *Thread, args []Value) Value {
 	if !th.Dbms().Use(ToStr(args[0])) {
@@ -29,7 +29,7 @@ func Use(th *Thread, args []Value) Value {
 	return True
 }
 
-var _ = builtin(Unuse, "(library) :boolean")
+var _ = builtin(Unuse, "(library :string) :boolean")
 
 func Unuse(th *Thread, args []Value) Value {
 	Global.UnloadAll()
@@ -47,7 +47,7 @@ func Unload(arg Value) Value {
 	return nil
 }
 
-var _ = builtin(LibraryOverride, "(lib, name, text='') :void")
+var _ = builtin(LibraryOverride, "(lib :string, name :string, text :string ='') :void")
 
 func LibraryOverride(lib, name, text Value) Value {
 	LibraryOverrides.Put(ToStr(lib), ToStr(name), ToStr(text))

--- a/builtin/lrucache.go
+++ b/builtin/lrucache.go
@@ -14,7 +14,7 @@ type suLruCacheGlobal struct {
 }
 
 func init() {
-	ps := params("(getfn, size=10, okForResetAll?=true)")
+	ps := params("(getfn, size=10, okForResetAll? :boolean =true)")
 	Global.Builtin("LruCache", &suLruCacheGlobal{
 		SuBuiltin{Fn: lruCacheCallClass,
 			BuiltinParams: BuiltinParams{ParamSpec: ps}}})

--- a/builtin/md5.go
+++ b/builtin/md5.go
@@ -48,7 +48,7 @@ func (suMd5) Lookup(_ *Thread, method string) Value {
 
 var md5Methods = methods("md5")
 
-var _ = method(md5_Update, "(string) :unknown")
+var _ = method(md5_Update, "(string :string) :unknown")
 
 func md5_Update(this, arg Value) Value {
 	io.WriteString(this.(suMd5).hash, ToStr(arg))

--- a/builtin/method.go
+++ b/builtin/method.go
@@ -5,7 +5,7 @@ package builtin
 
 import . "github.com/apmckinlay/gsuneido/core"
 
-var _ = builtin(Method, "(object, methodName) :false|unknown")
+var _ = builtin(Method, "(object, methodName :string) :false|unknown")
 
 func Method(th *Thread, args []Value) Value {
 	ob := args[0]

--- a/builtin/object.go
+++ b/builtin/object.go
@@ -265,7 +265,7 @@ func ob_Set_readonly(this Value) Value {
 	return this
 }
 
-var _ = method(ob_Size, "(list=false,named=false) :number")
+var _ = method(ob_Size, "(list :boolean =false,named :boolean =false) :number")
 
 func ob_Size(this, arg1, arg2 Value) Value {
 	list := ToBool(arg1)

--- a/builtin/openpgp.go
+++ b/builtin/openpgp.go
@@ -41,7 +41,7 @@ func (*suOpenPGP) Lookup(_ *Thread, method string) Value {
 var openpgpMethods = methods("opgp")
 
 var _ = staticMethod(opgp_SymmetricEncrypt,
-	"(passphrase, source, toFile = false) :string|void")
+	"(passphrase :string, source :string, toFile = false) :string|void")
 
 func opgp_SymmetricEncrypt(passphrase, source, toFile Value) Value {
 	if toFile == False {
@@ -51,7 +51,7 @@ func opgp_SymmetricEncrypt(passphrase, source, toFile Value) Value {
 }
 
 var _ = staticMethod(opgp_SymmetricDecrypt,
-	"(passphrase, source, toFile = false) :string|void")
+	"(passphrase, source :string, toFile = false) :string|void")
 
 func opgp_SymmetricDecrypt(passphrase, source, toFile Value) Value {
 	if toFile == False {
@@ -61,7 +61,7 @@ func opgp_SymmetricDecrypt(passphrase, source, toFile Value) Value {
 }
 
 var _ = staticMethod(opgp_PublicEncrypt,
-	"(publicKey, source, toFile = false) :string|void")
+	"(publicKey :string, source :string, toFile = false) :string|void")
 
 func opgp_PublicEncrypt(publicKey, source, toFile Value) Value {
 	if toFile == False {
@@ -71,7 +71,7 @@ func opgp_PublicEncrypt(publicKey, source, toFile Value) Value {
 }
 
 var _ = staticMethod(opgp_PrivateDecrypt,
-	"(privateKey, passphrase, source, toFile = false) :string|void")
+	"(privateKey :string, passphrase :string, source :string, toFile = false) :string|void")
 
 func opgp_PrivateDecrypt(privateKey, passphrase, source, toFile Value) Value {
 	kp := keyPair{privateKey: ToStr(privateKey), passphrase: ToStr(passphrase)}
@@ -86,7 +86,7 @@ type keyPair struct {
 	passphrase string
 }
 
-var _ = staticMethod(opgp_KeyGen, "(name, email, passphrase) :object")
+var _ = staticMethod(opgp_KeyGen, "(name :string, email :string, passphrase :string) :object")
 
 func opgp_KeyGen(name, email, passphrase Value) Value {
 	const rsaBits = 2048
@@ -100,7 +100,7 @@ func opgp_KeyGen(name, email, passphrase Value) Value {
 	return ob
 }
 
-var _ = staticMethod(opgp_KeyId, "(key) :string")
+var _ = staticMethod(opgp_KeyId, "(key :string) :string")
 
 func opgp_KeyId(key Value) Value {
 	entity, err := openpgputil.ReadArmoredEntity(ToStr(key))
@@ -108,7 +108,7 @@ func opgp_KeyId(key Value) Value {
 	return SuStr(openpgputil.KeyIDHex(entity))
 }
 
-var _ = staticMethod(opgp_KeyEntity, "(key) :false|string")
+var _ = staticMethod(opgp_KeyEntity, "(key :string) :false|string")
 
 func opgp_KeyEntity(key Value) Value {
 	entity, err := openpgputil.ReadArmoredEntity(ToStr(key))

--- a/builtin/openpgp.go
+++ b/builtin/openpgp.go
@@ -51,7 +51,7 @@ func opgp_SymmetricEncrypt(passphrase, source, toFile Value) Value {
 }
 
 var _ = staticMethod(opgp_SymmetricDecrypt,
-	"(passphrase, source :string, toFile = false) :string|void")
+	"(passphrase :string, source :string, toFile = false) :string|void")
 
 func opgp_SymmetricDecrypt(passphrase, source, toFile Value) Value {
 	if toFile == False {

--- a/builtin/pack.go
+++ b/builtin/pack.go
@@ -19,7 +19,7 @@ func pack(arg Value) Value {
 	return SuStr(PackValue(arg))
 }
 
-var _ = builtin(unpack, "(string) :unknown")
+var _ = builtin(unpack, "(string :string) :unknown")
 
 func unpack(arg Value) Value {
 	defer func() {

--- a/builtin/pdfencrypt.go
+++ b/builtin/pdfencrypt.go
@@ -47,7 +47,7 @@ var pe_members = methodList(pdfEncryptMethods)
 
 // The value -1028 allows a user to print the document and use screen readers
 // while strictly prohibiting them from copying text, editing content, or modifying the page structure.
-var _ = staticMethod(pe_KeyEntries, "(userPass, ownerPass, permissions = -1028) :object")
+var _ = staticMethod(pe_KeyEntries, "(userPass :string, ownerPass :string, permissions = -1028) :object")
 
 // pe_KeyEntries generates PDF encryption dictionary entries for AES-256 (Revision: 5, Version: 5, AESV3)
 // Based on PDF 1.7 Extension Level 3 and ISO 32000-1 Algorithm 3.2a
@@ -194,7 +194,7 @@ func aesEncryptCBCZeroIV(data, key []byte) []byte {
 	return encrypted
 }
 
-var _ = staticMethod(pe_Encrypt, "(data, encryptionKey) :string")
+var _ = staticMethod(pe_Encrypt, "(data :string, encryptionKey :string) :string")
 
 func pe_Encrypt(data, encryptionKey Value) Value {
 	dataBytes, err := hex.DecodeString(ToStr(data))

--- a/builtin/pipe.go
+++ b/builtin/pipe.go
@@ -72,7 +72,7 @@ func piper_Close(this Value) Value {
 
 var suPipeWriterMethods = methods("pipew")
 
-var _ = method(pipew_Write, "(s) :void")
+var _ = method(pipew_Write, "(s :string) :void")
 
 func pipew_Write(this Value, a Value) Value {
 	wr := this.(*suPipeWriter).wr

--- a/builtin/print.go
+++ b/builtin/print.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(PrintStdout, "(string) :void")
+var _ = builtin(PrintStdout, "(string :string) :void")
 
 func PrintStdout(_ *Thread, args []Value) Value {
 	s := ToStr(args[0])

--- a/builtin/query.go
+++ b/builtin/query.go
@@ -123,7 +123,7 @@ func query_Prev(th *Thread, this Value, _ []Value) Value {
 	return this.(*SuQuery).GetRec(th, Prev)
 }
 
-var _ = method(query_Output, "(record) :void")
+var _ = method(query_Output, "(record :object) :void")
 
 func query_Output(th *Thread, this Value, args []Value) Value {
 	trace.Dbms.Println("Query Output", this, args[0])
@@ -150,7 +150,7 @@ func query_RuleColumns(this Value) Value {
 	return this.(ISuQueryCursor).RuleColumns()
 }
 
-var _ = method(query_Strategy, "(formatted = false) :string")
+var _ = method(query_Strategy, "(formatted :boolean = false) :string")
 
 func query_Strategy(_ *Thread, this Value, args []Value) Value {
 	formatted := ToBool(args[0])
@@ -163,7 +163,7 @@ func query_Tree(this Value) Value {
 	return this.(ISuQueryCursor).Tree()
 }
 
-var _ = builtin(formatQuery, "(query) :string")
+var _ = builtin(formatQuery, "(query :string) :string")
 
 func formatQuery(th *Thread, args []Value) Value {
 	if dbms, ok := th.Dbms().(*dbms.DbmsLocal); ok {
@@ -198,21 +198,21 @@ func (*suQueryStatic) Lookup(th *Thread, method string) Value {
 
 var queryStaticMethods = methods("sqs")
 
-var _ = staticMethod(sqs_StripSort, "(query) :string")
+var _ = staticMethod(sqs_StripSort, "(query :string) :string")
 
 func sqs_StripSort(arg Value) Value {
 	query := ToStr(arg)
 	return SuStr(qry.StripSort(query))
 }
 
-var _ = staticMethod(sqs_GetSort, "(query) :string")
+var _ = staticMethod(sqs_GetSort, "(query :string) :string")
 
 func sqs_GetSort(arg Value) Value {
 	query := ToStr(arg)
 	return SuStr(qry.GetSort(query))
 }
 
-var _ = staticMethod(sqs_Parse, "(parse) :unknown")
+var _ = staticMethod(sqs_Parse, "(parse :string) :unknown")
 
 func sqs_Parse(th *Thread, args []Value) Value {
 	dbms, ok := th.Dbms().(*dbms.DbmsLocal)

--- a/builtin/queryalt.go
+++ b/builtin/queryalt.go
@@ -25,7 +25,7 @@ func QueryAlt(th *Thread, as *ArgSpec, args []Value) Value {
 	return ob
 }
 
-var _ = builtin(QueryAltHash, "(query, details=false) :string|number")
+var _ = builtin(QueryAltHash, "(query :string, details :boolean =false) :string|number")
 
 func QueryAltHash(th *Thread, args []Value) Value {
 	query := ToStr(args[0]) + `

--- a/builtin/queryhash.go
+++ b/builtin/queryhash.go
@@ -8,7 +8,7 @@ import (
 	qry "github.com/apmckinlay/gsuneido/dbms/query"
 )
 
-var _ = builtin(QueryHash, "(query, details=false) :number|string")
+var _ = builtin(QueryHash, "(query :string, details :boolean =false) :number|string")
 
 func QueryHash(th *Thread, args []Value) Value {
 	query := ToStr(args[0]) + `

--- a/builtin/queryscanner.go
+++ b/builtin/queryscanner.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(QueryScanner, "(string) :unknown")
+var _ = builtin(QueryScanner, "(string :string) :unknown")
 
 func QueryScanner(arg Value) Value {
 	return &suScanner{name: "QueryScanner",

--- a/builtin/random.go
+++ b/builtin/random.go
@@ -38,7 +38,7 @@ func initRand(th *Thread) {
 
 var randomMethods = methods("rnd")
 
-var _ = staticMethod(rnd_Seed, "(seed) :void")
+var _ = staticMethod(rnd_Seed, "(seed :number) :void")
 
 func rnd_Seed(th *Thread, args []Value) Value {
 	seed := uint64(IfInt(args[0]))

--- a/builtin/record.go
+++ b/builtin/record.go
@@ -30,7 +30,7 @@ func record_Clear(this Value) Value {
 	return nil
 }
 
-var _ = method(record_GetDeps, "(field) :string")
+var _ = method(record_GetDeps, "(field :string) :string")
 
 func record_GetDeps(this, arg Value) Value {
 	return this.(*SuRecord).GetDeps(ToStr(arg))
@@ -98,7 +98,7 @@ func record_RemoveObserver(this, arg Value) Value {
 	return SuBool(this.(*SuRecord).RemoveObserver(arg))
 }
 
-var _ = method(record_SetDeps, "(field,deps) :void")
+var _ = method(record_SetDeps, "(field :string,deps :string) :void")
 
 func record_SetDeps(this, arg1, arg2 Value) Value {
 	this.(*SuRecord).SetDeps(ToStr(arg1), ToStr(arg2))

--- a/builtin/runpiped.go
+++ b/builtin/runpiped.go
@@ -25,7 +25,7 @@ type suRunPiped struct {
 var nRunPiped atomic.Int32
 var _ = AddInfo("builtin.nRunPiped", &nRunPiped)
 
-var _ = builtin(RunPiped, "(command, block=false) :unknown")
+var _ = builtin(RunPiped, "(command :string, block=false) :unknown")
 
 func RunPiped(th *Thread, args []Value) Value {
 	guardSandbox("RunPiped")

--- a/builtin/scanner.go
+++ b/builtin/scanner.go
@@ -18,7 +18,7 @@ type suScanner struct {
 	MayLock
 }
 
-var _ = builtin(Scanner, "(string) :unknown")
+var _ = builtin(Scanner, "(string :string) :unknown")
 
 func Scanner(arg Value) Value {
 	return &suScanner{lxr: *lexer.NewLexer(ToStr(arg)), name: "Scanner"}

--- a/builtin/sequence.go
+++ b/builtin/sequence.go
@@ -109,7 +109,7 @@ func seq_Iter(this Value) Value {
 	return SuIter{Iter: iter}
 }
 
-var _ = method(seq_Join, "(separator='') :string")
+var _ = method(seq_Join, "(separator :string ='') :string")
 
 func seq_Join(this, arg Value) Value {
 	iter := this.(*SuSequence).Iter()

--- a/builtin/sha1.go
+++ b/builtin/sha1.go
@@ -48,7 +48,7 @@ func (suSha1) Lookup(_ *Thread, method string) Value {
 
 var sha1Methods = methods("Sha1")
 
-var _ = method(Sha1_Update, "(string) :unknown")
+var _ = method(Sha1_Update, "(string :string) :unknown")
 
 func Sha1_Update(this, arg Value) Value {
 	io.WriteString(this.(suSha1).hash, ToStr(arg))

--- a/builtin/sha256.go
+++ b/builtin/sha256.go
@@ -48,7 +48,7 @@ func (suSha256) Lookup(_ *Thread, method string) Value {
 
 var sha256Methods = methods("Sha256")
 
-var _ = method(Sha256_Update, "(string) :unknown")
+var _ = method(Sha256_Update, "(string :string) :unknown")
 
 func Sha256_Update(this, arg Value) Value {
 	io.WriteString(this.(suSha256).hash, ToStr(arg))

--- a/builtin/socketclient.go
+++ b/builtin/socketclient.go
@@ -25,7 +25,7 @@ var nSocketClient atomic.Int32
 var _ = AddInfo("builtin.nSocketClient", &nSocketClient)
 
 var _ = builtin(SocketClient,
-	"(ipaddress, port, timeout=60, timeoutConnect=0, block=false) :unknown")
+	"(ipaddress :string, port, timeout=60, timeoutConnect=0, block=false) :unknown")
 
 func SocketClient(th *Thread, args []Value) Value {
 	guardSandbox("SocketClient")

--- a/builtin/string.go
+++ b/builtin/string.go
@@ -91,7 +91,7 @@ func string_Compile(th *Thread, this Value, args []Value) Value {
 	return val
 }
 
-var _ = method(string_Count, "(string) :number")
+var _ = method(string_Count, "(string :string) :number")
 
 func string_Count(this, arg Value) Value {
 	return IntVal(strings.Count(ToStr(this), ToStr(arg)))
@@ -158,7 +158,7 @@ func string_Extract(th *Thread, this Value, args []Value) Value {
 	return SuStr(s[pos:end])
 }
 
-var _ = method(string_Find, "(string, pos=0) :number")
+var _ = method(string_Find, "(string :string, pos=0) :number")
 
 func string_Find(this, arg1, arg2 Value) Value {
 	s := ToStr(this)
@@ -170,7 +170,7 @@ func string_Find(this, arg1, arg2 Value) Value {
 	return IntVal(pos + i)
 }
 
-var _ = method(string_Find1of, "(chars, pos=0) :number")
+var _ = method(string_Find1of, "(chars :string, pos=0) :number")
 
 func string_Find1of(this, arg1, arg2 Value) Value {
 	s := ToStr(this)
@@ -182,7 +182,7 @@ func string_Find1of(this, arg1, arg2 Value) Value {
 	return IntVal(pos + i)
 }
 
-var _ = method(string_FindLast, "(string, pos=false) :false|number")
+var _ = method(string_FindLast, "(string :string, pos=false) :false|number")
 
 func string_FindLast(this, arg1, arg2 Value) Value {
 	s := ToStr(this)
@@ -203,7 +203,7 @@ func string_FindLast(this, arg1, arg2 Value) Value {
 	return intOrFalse(strings.LastIndex(s[:end], substr))
 }
 
-var _ = method(string_FindLast1of, "(chars, pos=false) :false|number")
+var _ = method(string_FindLast1of, "(chars :string, pos=false) :false|number")
 
 func string_FindLast1of(this, arg1, arg2 Value) Value {
 	set := ToStr(arg1)
@@ -231,7 +231,7 @@ func string_FromUtf8(this Value) Value {
 	return SuStr(s)
 }
 
-var _ = method(string_HasQ, "(string) :boolean")
+var _ = method(string_HasQ, "(string :string) :boolean")
 
 func string_HasQ(this, arg Value) Value {
 	return SuBool(strings.Contains(ToStr(this), ToStr(arg)))
@@ -264,7 +264,7 @@ func string_LowerQ(this Value) Value {
 	return SuBool(result)
 }
 
-var _ = method(string_MapN, "(n, block) :string")
+var _ = method(string_MapN, "(n :number, block) :string")
 
 func string_MapN(th *Thread, this Value, args []Value) Value {
 	s := ToStr(this)
@@ -283,7 +283,7 @@ func string_MapN(th *Thread, this Value, args []Value) Value {
 	return SuStr(buf.String())
 }
 
-var _ = method(string_Match, "(pattern, pos=false, prev=false) :false|object")
+var _ = method(string_Match, "(pattern, pos=false, prev :boolean =false) :false|object")
 
 func string_Match(th *Thread, this Value, args []Value) Value {
 	s := ToStr(this)
@@ -368,7 +368,7 @@ func string_NumericQ(this Value) Value {
 	return True
 }
 
-var _ = method(string_PrefixQ, "(string, pos=0) :boolean")
+var _ = method(string_PrefixQ, "(string :string, pos=0) :boolean")
 
 func string_PrefixQ(this, arg1, arg2 Value) Value {
 	s := ToStr(this)
@@ -424,7 +424,7 @@ func string_Size(this Value) Value {
 	// "this" should always have Len
 }
 
-var _ = method(string_Split, "(separator = '') :object")
+var _ = method(string_Split, "(separator :string = '') :object")
 
 func string_Split(this, arg Value) Value {
 	s := ToStr(this)
@@ -448,7 +448,7 @@ func string_Split(this, arg Value) Value {
 	return NewSuObject(vals)
 }
 
-var _ = method(string_SuffixQ, "(string) :boolean")
+var _ = method(string_SuffixQ, "(string :string) :boolean")
 
 func string_SuffixQ(this, arg Value) Value {
 	return SuBool(strings.HasSuffix(ToStr(this), ToStr(arg)))
@@ -484,7 +484,7 @@ func string_ToUtf8(this Value) Value {
 	return SuStr(utf8)
 }
 
-var _ = method(string_Tr, "(from, to='') :string")
+var _ = method(string_Tr, "(from :string, to :string ='') :string")
 
 func string_Tr(th *Thread, this Value, args []Value) Value {
 	from := th.TrSet(args[0])

--- a/builtin/suneido.go
+++ b/builtin/suneido.go
@@ -19,7 +19,7 @@ import (
 
 var _ = exportMethods(&SuneidoObjectMethods, "suneido")
 
-var _ = staticMethod(suneido_Compile, "(source, errob = false) :unknown")
+var _ = staticMethod(suneido_Compile, "(source :string, errob = false) :unknown")
 
 func suneido_Compile(th *Thread, args []Value) Value {
 	src := ToStr(args[0])
@@ -34,7 +34,7 @@ func suneido_Compile(th *Thread, args []Value) Value {
 	return val
 }
 
-var _ = staticMethod(suneido_Parse, "(source) :unknown")
+var _ = staticMethod(suneido_Parse, "(source :string) :unknown")
 
 func suneido_Parse(th *Thread, args []Value) Value {
 	src := ToStr(args[0])
@@ -46,7 +46,7 @@ func suneido_Parse(th *Thread, args []Value) Value {
 	return ast
 }
 
-var _ = staticMethod(suneido_Regex, "(pattern) :unknown")
+var _ = staticMethod(suneido_Regex, "(pattern :string) :unknown")
 
 func suneido_Regex(arg Value) Value {
 	return SuRegex{Pat: regex.Compile(ToStr(arg))}
@@ -106,14 +106,14 @@ func suneido_RuntimeError() Value {
 	return Nil[123]
 }
 
-var _ = staticMethod(suneido_StrictCompare, "(bool) :void")
+var _ = staticMethod(suneido_StrictCompare, "(bool :boolean) :void")
 
 func suneido_StrictCompare(x Value) Value {
 	options.StrictCompare = ToBool(x)
 	return nil
 }
 
-var _ = staticMethod(suneido_StrictCompareDb, "(bool) :void")
+var _ = staticMethod(suneido_StrictCompareDb, "(bool :boolean) :void")
 
 func suneido_StrictCompareDb(x Value) Value {
 	options.StrictCompareDb = ToBool(x)
@@ -145,7 +145,7 @@ func suneido_Info(x Value) Value {
 	return InfoStr(ToStr(x))
 }
 
-var _ = method(suneido_Members, "(all = false) :object")
+var _ = method(suneido_Members, "(all :boolean = false) :object")
 
 func suneido_Members(this Value, all Value) Value {
 	if !ToBool(all) {

--- a/builtin/sys.go
+++ b/builtin/sys.go
@@ -46,7 +46,7 @@ func GetCurrentDirectory() Value {
 
 // NOTE: temp file is NOT deleted automatically on exit
 // (same as cSuneido, but different from jSuneido)
-var _ = builtin(GetTempFileName, "(path, prefix) :string")
+var _ = builtin(GetTempFileName, "(path :string, prefix :string) :string")
 
 func GetTempFileName(path, prefix Value) Value {
 	tmpDir := ToStr(path)
@@ -67,7 +67,7 @@ func GetTempFileName(path, prefix Value) Value {
 	return SuStr(filename)
 }
 
-var _ = builtin(CreateDir, "(dirname) :string|true")
+var _ = builtin(CreateDir, "(dirname :string) :string|true")
 
 func CreateDir(th *Thread, args []Value) Value {
 	path := ToStr(args[0])
@@ -94,7 +94,7 @@ func CreateDir(th *Thread, args []Value) Value {
 	return True
 }
 
-var _ = builtin(EnsureDir, "(dirname) :string|true")
+var _ = builtin(EnsureDir, "(dirname :string) :string|true")
 
 func EnsureDir(th *Thread, args []Value) Value {
 	path := ToStr(args[0])
@@ -120,7 +120,7 @@ func EnsureDir(th *Thread, args []Value) Value {
 	return True
 }
 
-var _ = builtin(DeleteFileApi, "(filename) :string|true")
+var _ = builtin(DeleteFileApi, "(filename :string) :string|true")
 
 func DeleteFileApi(th *Thread, args []Value) Value {
 	path := ToStr(args[0])
@@ -145,7 +145,7 @@ func DeleteFileApi(th *Thread, args []Value) Value {
 	return True
 }
 
-var _ = builtin(FileExistsQ, "(filename) :boolean")
+var _ = builtin(FileExistsQ, "(filename :string) :boolean")
 
 func FileExistsQ(arg Value) Value {
 	path := ToStr(arg)
@@ -163,7 +163,7 @@ func FileExistsQ(arg Value) Value {
 	return SuBool(err == nil && info.Mode().IsRegular())
 }
 
-var _ = builtin(DirExistsQ, "(filename) :boolean")
+var _ = builtin(DirExistsQ, "(filename :string) :boolean")
 
 func DirExistsQ(arg Value) Value {
 	path := ToStr(arg)
@@ -181,7 +181,7 @@ func DirExistsQ(arg Value) Value {
 	return SuBool(err == nil && info.Mode().IsDir())
 }
 
-var _ = builtin(MoveFile, "(from, to) :string|true")
+var _ = builtin(MoveFile, "(from :string, to :string) :string|true")
 
 func MoveFile(th *Thread, args []Value) Value {
 	from := ToStr(args[0])
@@ -208,7 +208,7 @@ func MoveFile(th *Thread, args []Value) Value {
 	return True
 }
 
-var _ = builtin(DeleteDir, "(dir) :string|true")
+var _ = builtin(DeleteDir, "(dir :string) :string|true")
 
 func DeleteDir(th *Thread, args []Value) Value {
 	path := ToStr(args[0])
@@ -276,7 +276,7 @@ func OSName() Value {
 	return SuStr(os)
 }
 
-var _ = builtin(FileSize, "(file) :number")
+var _ = builtin(FileSize, "(file :string) :number")
 
 func FileSize(th *Thread, args []Value) Value {
 	path := ToStr(args[0])

--- a/builtin/sys_unix.go
+++ b/builtin/sys_unix.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(GetDiskFreeSpace, "(dir = '.') :number")
+var _ = builtin(GetDiskFreeSpace, "(dir :string = '.') :number")
 
 func GetDiskFreeSpace(arg Value) Value {
 	var stat syscall.Statfs_t
@@ -27,7 +27,7 @@ func GetDiskFreeSpace(arg Value) Value {
 	return Int64Val(int64(freeBytes))
 }
 
-var _ = builtin(CopyFile, "(from, to, failIfExists) :string|true")
+var _ = builtin(CopyFile, "(from :string, to :string, failIfExists :boolean) :string|true")
 
 func CopyFile(th *Thread, args []Value) Value {
 	from := ToStr(args[0])

--- a/builtin/sys_windows.go
+++ b/builtin/sys_windows.go
@@ -29,7 +29,7 @@ var kernel32 = windows.MustLoadDLL("kernel32.dll")
 
 var getDiskFreeSpaceEx = kernel32.MustFindProc("GetDiskFreeSpaceExA").Addr()
 
-var _ = builtin(GetDiskFreeSpace, "(dir = '.') :number")
+var _ = builtin(GetDiskFreeSpace, "(dir :string = '.') :number")
 
 func GetDiskFreeSpace(arg Value) Value {
 	var n int64
@@ -66,7 +66,7 @@ func systemMemory() uint64 {
 }
 
 var copyFile = kernel32.MustFindProc("CopyFileA").Addr()
-var _ = builtin(CopyFile, "(from, to, failIfExists) :string|true")
+var _ = builtin(CopyFile, "(from :string, to :string, failIfExists :boolean) :string|true")
 
 func CopyFile(th *Thread, args []Value) Value {
 	if sandboxed() {

--- a/builtin/system.go
+++ b/builtin/system.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/apmckinlay/gsuneido/core"
 )
 
-var _ = builtin(System, "(command) :number")
+var _ = builtin(System, "(command :string) :number")
 
 func System(th *Thread, args []Value) Value {
 	guardSandbox("System")

--- a/builtin/waitgroup.go
+++ b/builtin/waitgroup.go
@@ -62,7 +62,7 @@ func wg_Thread(th *Thread, this Value, args []Value) Value {
 	return nil
 }
 
-var _ = method(wg_Wait, "(secs = 10) :true")
+var _ = method(wg_Wait, "(secs :number = 10) :true")
 
 func wg_Wait(th *Thread, this Value, args []Value) Value {
 	timeout := IfInt(args[0])

--- a/builtin/widechar.go
+++ b/builtin/widechar.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-var _ = builtin(WideCharToMultiByte, "(string, cp = 1252) :string")
+var _ = builtin(WideCharToMultiByte, "(string :string, cp = 1252) :string")
 
 func WideCharToMultiByte(s, c Value) Value {
 	// UTF-16 to 1252 or UTF-8
@@ -33,7 +33,7 @@ func WideCharToMultiByte(s, c Value) Value {
 	return SuStr(s1252)
 }
 
-var _ = builtin(MultiByteToWideChar, "(string, cp = 1252) :string")
+var _ = builtin(MultiByteToWideChar, "(string :string, cp = 1252) :string")
 
 func MultiByteToWideChar(str, cp Value) Value {
 	// 1252 or UTF-8 to UTF-16

--- a/builtin/zlib.go
+++ b/builtin/zlib.go
@@ -34,7 +34,7 @@ func (*suZlib) Lookup(_ *Thread, method string) Value {
 
 var zlibMethods = methods("zlib")
 
-var _ = staticMethod(zlib_Compress, "(string) :string")
+var _ = staticMethod(zlib_Compress, "(string :string) :string")
 
 func zlib_Compress(arg Value) Value {
 	s := ToStr(arg)
@@ -52,7 +52,7 @@ func zlib_Compress(arg Value) Value {
 	return SuStr(b.String())
 }
 
-var _ = staticMethod(zlib_Uncompress, "(string) :string")
+var _ = staticMethod(zlib_Uncompress, "(string :string) :string")
 
 func zlib_Uncompress(arg Value) Value {
 	data := ToStr(arg)


### PR DESCRIPTION
The type checker also now supports call site type checking for params

```suneido
Dates()
		{
		d = Date()
		d.MinusDays(Date()); d.FormatEn("dd MMM")
		d.MinusDays("2020")
		d.MinusDays(30)
		d.FormatEn(false)
		}
``` 
will show errors as,
```
ahplib:InBuiltParams:24 ERROR: Dates [0.90] argument "format": type False not assignable to declared String
ahplib:InBuiltParams:23 ERROR: Dates [0.90] argument "date": type Number not assignable to declared Date
ahplib:InBuiltParams:22 ERROR: Dates [0.90] argument "date": type String not assignable to declared Date
```

